### PR TITLE
Part 1 of influx2cortex and mimir-proxies package consolidation

### DIFF
--- a/pkg/remotewrite/client.go
+++ b/pkg/remotewrite/client.go
@@ -32,8 +32,6 @@ import (
 const (
 	// maxErrMsgLen is copied from github.com/prometheus/prometheus/storage/remote
 	maxErrMsgLen = 512
-
-	userAgent = "datadog-proxy/ingester"
 )
 
 const defaultWriteTimeout = 1 * time.Second
@@ -51,6 +49,7 @@ type Config struct {
 	MaxIdleConns        int           `yaml:"max_idle_conns"`
 	MaxConns            int           `yaml:"max_conns"`
 	SkipLabelValidation bool          `yaml:"skip_label_validation"`
+	UserAgent           string        `yaml:"user_agent"`
 }
 
 // RegisterFlags implements flagext.Registerer
@@ -72,6 +71,7 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, flags *flag.FlagSet) {
 	flags.IntVar(&c.MaxIdleConns, prefix+"write-max-idle-conns", 10, "Max idle conns per host for writes to upstream Prometheus remote write API.")
 	flags.IntVar(&c.MaxConns, prefix+"write-max-conns", 100, "Max open conns per host for writes to upstream Prometheus remote write API.")
 	flags.BoolVar(&c.SkipLabelValidation, prefix+"skip-label-validation", false, "If set to true sends requests with headers to skip label validation.")
+	flags.StringVar(&c.UserAgent, prefix+"user-agent", "", "User agent for proxy ingester")
 }
 
 // NewClient creates the default http implementation of the Client
@@ -138,7 +138,7 @@ func (c *client) Write(ctx context.Context, req *mimirpb.WriteRequest) error {
 
 	httpReq.Header.Add("Content-Encoding", "snappy")
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
-	httpReq.Header.Set("User-Agent", userAgent)
+	httpReq.Header.Set("User-Agent", c.cfg.UserAgent)
 	httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
 	if c.cfg.SkipLabelValidation {
 		httpReq.Header.Set(push.SkipLabelNameValidationHeader, "true")

--- a/pkg/remotewrite/client_test.go
+++ b/pkg/remotewrite/client_test.go
@@ -123,7 +123,7 @@ func TestHTTPRemoteWriteClient_Write(t *testing.T) {
 }
 
 const outOfOrderSampleResponseText = "user=41413: err: out of order sample. " +
-	`timestamp=2021-02-16T10:07:30Z, series={__name__=\"datadog_dot_dogstatsd_dot_client_dot_events\", ` +
+	`timestamp=2021-02-16T10:07:30Z, series={__name__=\"my_proxy_dot_statsd_dot_client_dot_events\", ` +
 	`client=\"go\", client__transport=\"udp\", client__version=\"4.2.0\", ` +
 	`cluster__name=\"dev-cluster\", ` +
 	`host=\"cluster.dev.internal\", ` +

--- a/pkg/remotewrite/recorder_test.go
+++ b/pkg/remotewrite/recorder_test.go
@@ -22,12 +22,12 @@ func TestRecorder(t *testing.T) {
 				r.measureOutOfOrderSamples(2)
 			},
 			expMetricNames: []string{
-				"datadog_proxy_out_of_order_writes_total",
+				"my_proxy_out_of_order_writes_total",
 			},
 			expMetrics: "" +
-				"# HELP datadog_proxy_out_of_order_writes_total The total number of out of order writes to Cortex.\n" +
-				"# TYPE datadog_proxy_out_of_order_writes_total counter\n" +
-				"datadog_proxy_out_of_order_writes_total 2\n",
+				"# HELP my_proxy_out_of_order_writes_total The total number of out of order writes to Cortex.\n" +
+				"# TYPE my_proxy_out_of_order_writes_total counter\n" +
+				"my_proxy_out_of_order_writes_total 2\n",
 		},
 	}
 
@@ -38,7 +38,7 @@ func TestRecorder(t *testing.T) {
 			// Init metric Recorder
 			reg := prometheus.NewRegistry()
 
-			rec := NewRecorder("datadog_proxy", reg)
+			rec := NewRecorder("my_proxy", reg)
 
 			// Measure metrics
 			test.measure(rec)
@@ -51,22 +51,22 @@ func TestRecorder(t *testing.T) {
 
 func TestRecorder_measure(t *testing.T) {
 	expectedTemplate := `
-		# HELP datadog_proxy_remote_write_client_request_duration_seconds Client-side duration of remote write calls.
-		# TYPE datadog_proxy_remote_write_client_request_duration_seconds histogram
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.005"} 0
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.01"} 1
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.025"} 1
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.05"} 1
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.1"} 1
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.25"} 1
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.5"} 1
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="1"} 1
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="2.5"} 1
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="5"} 1
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="10"} 1
-		datadog_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="+Inf"} 1
-		datadog_proxy_remote_write_client_request_duration_seconds_sum{operation="foo",result="<RESULT>"} 0.01
-		datadog_proxy_remote_write_client_request_duration_seconds_count{operation="foo",result="<RESULT>"} 1
+		# HELP my_proxy_remote_write_client_request_duration_seconds Client-side duration of remote write calls.
+		# TYPE my_proxy_remote_write_client_request_duration_seconds histogram
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.005"} 0
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.01"} 1
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.025"} 1
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.05"} 1
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.1"} 1
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.25"} 1
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="0.5"} 1
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="1"} 1
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="2.5"} 1
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="5"} 1
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="10"} 1
+		my_proxy_remote_write_client_request_duration_seconds_bucket{operation="foo",result="<RESULT>",le="+Inf"} 1
+		my_proxy_remote_write_client_request_duration_seconds_sum{operation="foo",result="<RESULT>"} 0.01
+		my_proxy_remote_write_client_request_duration_seconds_count{operation="foo",result="<RESULT>"} 1
 	`
 	for _, tc := range []struct {
 		result string
@@ -77,12 +77,12 @@ func TestRecorder_measure(t *testing.T) {
 	} {
 		t.Run(tc.result, func(t *testing.T) {
 			reg := prometheus.NewRegistry()
-			recorder := NewRecorder("datadog_proxy", reg)
+			recorder := NewRecorder("my_proxy", reg)
 			recorder.measure("foo", 10*time.Millisecond, tc.err)
 
 			expected := strings.ReplaceAll(expectedTemplate, "<RESULT>", tc.result)
 			err := testutil.GatherAndCompare(reg, strings.NewReader(expected),
-				"datadog_proxy_remote_write_client_request_duration_seconds",
+				"my_proxy_remote_write_client_request_duration_seconds",
 			)
 			assert.NoError(t, err)
 		})

--- a/pkg/server/middleware/logging_test.go
+++ b/pkg/server/middleware/logging_test.go
@@ -23,7 +23,7 @@ func TestLogRequest(t *testing.T) {
 		buf := new(bytes.Buffer)
 		logger := log.NewLogfmtLogger(buf)
 
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://grafana.net%s?api_key=%s", path, secretAPIKey), http.NoBody)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://example.com%s?api_key=%s", path, secretAPIKey), http.NoBody)
 		require.NoError(t, err)
 
 		logRequest(logger, req, http.StatusOK)
@@ -41,7 +41,7 @@ func TestLogRequest(t *testing.T) {
 		buf := new(bytes.Buffer)
 		logger := log.NewLogfmtLogger(buf)
 
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://grafana.net%s?api_key=%s", path, grafanaLabsAPIKey), http.NoBody)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://example.com%s?api_key=%s", path, grafanaLabsAPIKey), http.NoBody)
 		require.NoError(t, err)
 
 		logRequest(logger, req, http.StatusOK)
@@ -59,7 +59,7 @@ func TestLogRequest(t *testing.T) {
 		buf := new(bytes.Buffer)
 		logger := log.NewLogfmtLogger(buf)
 
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://grafana.net%s", path), http.NoBody)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://example.com%s", path), http.NoBody)
 		require.NoError(t, err)
 
 		logRequest(logger, req, http.StatusOK)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -65,16 +65,16 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, flags *flag.FlagSet) {
 	if prefix != "" && !strings.HasSuffix(prefix, ".") {
 		prefix += "."
 	}
-	flags.StringVar(&cfg.HTTPListenAddress, prefix+"server.http-listen-address", "0.0.0.0", "Sets listen address for the http server.")
-	flags.IntVar(&cfg.HTTPListenPort, prefix+"server.http-listen-port", defaultListenPort, "Sets listen address port for the http server.")
-	flags.IntVar(&cfg.HTTPConnLimit, prefix+"server.http-listen-conn-limit", 0, "Sets a limit to the amount of http connections. Defaults to no limit.")
-	flags.DurationVar(&cfg.ServerGracefulShutdownTimeout, prefix+"server.graceful-shutdown-timeout", defaultServerGracefulShutdown, "Graceful shutdown period. Defaults to 5 seconds.")
-	flags.DurationVar(&cfg.HTTPServerReadTimeout, prefix+"server.http-server-read-timeout", defaultHTTPReadTimeout, "HTTP request read timeout. Defaults to 30 seconds.")
-	flags.DurationVar(&cfg.HTTPServerWriteTimeout, prefix+"server.http-server-write-timeout", defaultHTTPWriteimeout, "HTTP request write timeout. Defaults to 30 seconds.")
-	flags.DurationVar(&cfg.HTTPServerIdleTimeout, prefix+"server.http-server-idle-timeout", defaultHTTPIdleimeout, "HTTP request idle timeout. Defaults to 30 seconds.")
-	flags.Int64Var(&cfg.HTTPMaxRequestSizeLimit, prefix+"server.http-max-req-size-limit", defaultHTTPRequestSizeLimit, "HTTP max request body size limit. Defaults to 10 mb.")
+	flags.StringVar(&cfg.HTTPListenAddress, prefix+"server.http-listen-address", "0.0.0.0", "Sets listen address for the http server")
+	flags.IntVar(&cfg.HTTPListenPort, prefix+"server.http-listen-port", defaultListenPort, "Sets listen address port for the http server")
+	flags.IntVar(&cfg.HTTPConnLimit, prefix+"server.http-listen-conn-limit", 0, "Sets a limit to the amount of http connections, 0 means no limit")
+	flags.DurationVar(&cfg.ServerGracefulShutdownTimeout, prefix+"server.graceful-shutdown-timeout", defaultServerGracefulShutdown, "Graceful shutdown period")
+	flags.DurationVar(&cfg.HTTPServerReadTimeout, prefix+"server.http-server-read-timeout", defaultHTTPReadTimeout, "HTTP request read timeout")
+	flags.DurationVar(&cfg.HTTPServerWriteTimeout, prefix+"server.http-server-write-timeout", defaultHTTPWriteimeout, "HTTP request write timeout")
+	flags.DurationVar(&cfg.HTTPServerIdleTimeout, prefix+"server.http-server-idle-timeout", defaultHTTPIdleimeout, "HTTP request idle timeout")
+	flags.Int64Var(&cfg.HTTPMaxRequestSizeLimit, prefix+"server.http-max-req-size-limit", defaultHTTPRequestSizeLimit, "HTTP max request body size limit in MB")
 	flags.StringVar(&cfg.PathPrefix, prefix+"server.path-prefix", "", "Base path to serve all API routes from (e.g. /v1/)")
-	flags.IntVar(&cfg.GRPCListenPort, prefix+"server.grpc-listen-port", defaultGrpcPort, "Sets listen address port for the http server.")
+	flags.IntVar(&cfg.GRPCListenPort, prefix+"server.grpc-listen-port", defaultGrpcPort, "Sets listen address port for the http server")
 }
 
 // Server initializes an Router webserver as well as the desired middleware configuration

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -17,7 +18,8 @@ import (
 func TestServerRun(t *testing.T) {
 	var cfg Config
 	cfg.RegisterFlags(flag.NewFlagSet("", flag.ExitOnError))
-	cfg.HTTPListenPort = 9097 // Override to avoid conflicting with other ports
+	cfg.HTTPListenPort = 0
+	cfg.HTTPListenAddress = "127.0.0.1"
 
 	logger := log.NewNopLogger()
 
@@ -28,10 +30,13 @@ func TestServerRun(t *testing.T) {
 		w.WriteHeader(204)
 	})
 
-	go server.Run()
+	go func() {
+		require.NoError(t, server.Run())
+	}()
+
 	defer server.Shutdown(nil)
 
-	req, err := http.NewRequest("GET", "http://127.0.0.1:9097/test", http.NoBody)
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/test", server.Addr()), http.NoBody)
 	require.NoError(t, err)
 	_, err = http.DefaultClient.Do(req)
 	require.NoError(t, err)


### PR DESCRIPTION
Package consolidation between influx2cortex and mimir-proxies

Packages shared by the write proxies (Influx, Graphite, Datadog) should reside in the mimir-proxies repository.

Influx2cortex had copied some of these packages into its own repository as mimir-proxies had not been open-sourced at this point. Now that the mimir-proxies repository is public we can undo the duplication.

This PR concerns the following packages:-
* pkg/appcommon
* pkg/remotewrite
* pkg/server
* pkg/server/middleware

and is attempting to consolidate the packages as of commit 31d5ec40eee81362645ae5f420b521f4195f58e1 in influx2cortex with the current head of mimir-proxies (commit 7458681c04bf5ad85b94218851ba1b99117a8ef6).

This PR is applied first to bring in the changes that were already in use in influx2cortex, and then https://github.com/grafana/influx2cortex/pull/66 can be merged which makes influx2cortex use these updated packages.