### PR TITLE
Add optional Tracer to appcommon.Config

### DIFF
--- a/cmd/datadog-proxy-writes/main.go
+++ b/cmd/datadog-proxy-writes/main.go
@@ -47,7 +47,7 @@ func Run() (err error) {
 
 	reg := prometheus.DefaultRegisterer
 
-	app, err := appcommon.New(appConfig, reg, metricPrefix)
+	app, err := appcommon.New(appConfig, reg, metricPrefix, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/graphite-proxy-writes/main.go
+++ b/cmd/graphite-proxy-writes/main.go
@@ -41,7 +41,7 @@ func Run() (err error) {
 	reg := prometheus.DefaultRegisterer
 
 	var app appcommon.App
-	app, err = appcommon.New(appConfig, reg, metricPrefix)
+	app, err = appcommon.New(appConfig, reg, metricPrefix, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/appcommon/harness.go
+++ b/pkg/appcommon/harness.go
@@ -32,10 +32,9 @@ var (
 )
 
 type Config struct {
-	InstrumentBuckets string             `yaml:"instrument_buckets"`
-	EnableAuth        bool               `yaml:"enable_auth"`
-	ServiceName       string             `yaml:"service_name"`
-	Tracer            opentracing.Tracer `yaml:"-"`
+	InstrumentBuckets string `yaml:"instrument_buckets"`
+	EnableAuth        bool   `yaml:"enable_auth"`
+	ServiceName       string `yaml:"service_name"`
 
 	ServerConfig         server.Config         `yaml:"server_config"`
 	InternalServerConfig internalserver.Config `yaml:"internal_server_config"`
@@ -81,7 +80,7 @@ func init() {
 
 // New creates a new App.
 // Callers should call App.Close() after use.
-func New(cfg Config, reg prometheus.Registerer, metricPrefix string) (app App, err error) {
+func New(cfg Config, reg prometheus.Registerer, metricPrefix string, tracer opentracing.Tracer) (app App, err error) {
 	if cfg.ServiceName == "" {
 		return app, fmt.Errorf("service name can't be empty")
 	}
@@ -113,8 +112,8 @@ func New(cfg Config, reg prometheus.Registerer, metricPrefix string) (app App, e
 		return app, fmt.Errorf("can't initialize the instrumentation middleware %w", err)
 	}
 
-	if cfg.Tracer != nil {
-		app.Tracer = cfg.Tracer
+	if tracer != nil {
+		app.Tracer = tracer
 	} else {
 		tracer, closer, err := NewTracer(cfg.ServiceName, logger)
 		if err != nil {

--- a/pkg/appcommon/harness.go
+++ b/pkg/appcommon/harness.go
@@ -113,8 +113,9 @@ func New(cfg Config, reg prometheus.Registerer, metricPrefix string) (app App, e
 		return app, fmt.Errorf("can't initialize the instrumentation middleware %w", err)
 	}
 
-	app.Tracer = cfg.Tracer
-	if cfg.Tracer == nil {
+	if cfg.Tracer != nil {
+		app.Tracer = cfg.Tracer
+	} else {
 		tracer, closer, err := NewTracer(cfg.ServiceName, logger)
 		if err != nil {
 			return app, err

--- a/pkg/appcommon/harness_test.go
+++ b/pkg/appcommon/harness_test.go
@@ -70,7 +70,7 @@ func TestApp_Close(t *testing.T) {
 
 func TestApp_Config_Tracer(t *testing.T) {
 	t.Run("tracer from config is set as global tracer", func(t *testing.T) {
-		defer tearDown(t)
+		defer resetTracingGlobals(t)
 
 		tracer := mocktracer.New()
 		app, err := New(Config{ServiceName: "test", Tracer: tracer, InstrumentBuckets: "0.1"}, prometheus.NewRegistry(), "")
@@ -82,7 +82,7 @@ func TestApp_Config_Tracer(t *testing.T) {
 	})
 
 	t.Run("new global tracer created if config tracer is nil", func(t *testing.T) {
-		defer tearDown(t)
+		defer resetTracingGlobals(t)
 
 		app, err := New(Config{ServiceName: "test", Tracer: nil, InstrumentBuckets: "0.1"}, prometheus.NewRegistry(), "")
 		require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestApp_Config_Tracer(t *testing.T) {
 	})
 }
 
-func tearDown(t *testing.T) {
+func resetTracingGlobals(t *testing.T) {
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	opentracing.SetGlobalTracer(nil)
 	require.Equal(t, nil, opentracing.GlobalTracer())

--- a/pkg/appcommon/harness_test.go
+++ b/pkg/appcommon/harness_test.go
@@ -73,7 +73,7 @@ func TestApp_Config_Tracer(t *testing.T) {
 		defer resetTracingGlobals(t)
 
 		tracer := mocktracer.New()
-		app, err := New(Config{ServiceName: "test", Tracer: tracer, InstrumentBuckets: "0.1"}, prometheus.NewRegistry(), "")
+		app, err := New(Config{ServiceName: "test", InstrumentBuckets: "0.1"}, prometheus.NewRegistry(), "", tracer)
 		require.NoError(t, err)
 		require.Equal(t, tracer, opentracing.GlobalTracer())
 
@@ -84,7 +84,7 @@ func TestApp_Config_Tracer(t *testing.T) {
 	t.Run("new global tracer created if config tracer is nil", func(t *testing.T) {
 		defer resetTracingGlobals(t)
 
-		app, err := New(Config{ServiceName: "test", Tracer: nil, InstrumentBuckets: "0.1"}, prometheus.NewRegistry(), "")
+		app, err := New(Config{ServiceName: "test", InstrumentBuckets: "0.1"}, prometheus.NewRegistry(), "", nil)
 		require.NoError(t, err)
 		require.NotNil(t, opentracing.GlobalTracer())
 

--- a/pkg/appcommon/harness_test.go
+++ b/pkg/appcommon/harness_test.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,4 +66,35 @@ func TestApp_Close(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+}
+
+func TestApp_Config_Tracer(t *testing.T) {
+	t.Run("tracer from config is set as global tracer", func(t *testing.T) {
+		defer tearDown(t)
+
+		tracer := mocktracer.New()
+		app, err := New(Config{ServiceName: "test", Tracer: tracer, InstrumentBuckets: "0.1"}, prometheus.NewRegistry(), "")
+		require.NoError(t, err)
+		require.Equal(t, tracer, opentracing.GlobalTracer())
+
+		err = app.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("new global tracer created if config tracer is nil", func(t *testing.T) {
+		defer tearDown(t)
+
+		app, err := New(Config{ServiceName: "test", Tracer: nil, InstrumentBuckets: "0.1"}, prometheus.NewRegistry(), "")
+		require.NoError(t, err)
+		require.NotNil(t, opentracing.GlobalTracer())
+
+		err = app.Close()
+		require.NoError(t, err)
+	})
+}
+
+func tearDown(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	opentracing.SetGlobalTracer(nil)
+	require.Equal(t, nil, opentracing.GlobalTracer())
 }


### PR DESCRIPTION
Add the ability to pass an opentracing.Tracer via appcommon.Config.Tracer

We are using harness.go as the basis for the Faro Endpoint, and we would like to configure the OpenTracing->OTel bridge tracer for use in our code ( https://github.com/grafana/app-o11y-kwl-endpoint/blob/main/cmd/kwl/main.go )

@rlankfo authored the 1st commit. I've attempted to add a test to show the behavior is correct.
I will squash the commits before merging if that is preferred?