### PR TITLE
Use io.LimitReader in RequestsLimits middleware

### DIFF
--- a/pkg/server/middleware/request_limits.go
+++ b/pkg/server/middleware/request_limits.go
@@ -19,7 +19,8 @@ func NewRequestLimitsMiddleware(maxRequestBodySize int64) *RequestLimits {
 
 func (l RequestLimits) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
+		reader := io.LimitReader(r.Body, int64(l.maxRequestBodySize)+1)
+		body, err := io.ReadAll(reader)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusInternalServerError)
 			return

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -72,7 +72,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, flags *flag.FlagSet) {
 	flags.DurationVar(&cfg.HTTPServerReadTimeout, prefix+"server.http-server-read-timeout", defaultHTTPReadTimeout, "HTTP request read timeout")
 	flags.DurationVar(&cfg.HTTPServerWriteTimeout, prefix+"server.http-server-write-timeout", defaultHTTPWriteimeout, "HTTP request write timeout")
 	flags.DurationVar(&cfg.HTTPServerIdleTimeout, prefix+"server.http-server-idle-timeout", defaultHTTPIdleimeout, "HTTP request idle timeout")
-	flags.Int64Var(&cfg.HTTPMaxRequestSizeLimit, prefix+"server.http-max-req-size-limit", defaultHTTPRequestSizeLimit, "HTTP max request body size limit in MB")
+	flags.Int64Var(&cfg.HTTPMaxRequestSizeLimit, prefix+"server.http-max-req-size-limit", defaultHTTPRequestSizeLimit, "HTTP max request body size limit in bytes")
 	flags.StringVar(&cfg.PathPrefix, prefix+"server.path-prefix", "", "Base path to serve all API routes from (e.g. /v1/)")
 	flags.IntVar(&cfg.GRPCListenPort, prefix+"server.grpc-listen-port", defaultGrpcPort, "Sets listen address port for the http server")
 }


### PR DESCRIPTION
Limit number of bytes read in cases where requests are larger than `server.http-max-req-size-limit`
This uses the same approach as Mimir for limiting memory used when payloads exceed maximum sizes - https://github.com/grafana/mimir/blob/main/pkg/util/http.go#L196-L212

Needed by https://github.com/grafana/deployment_tools/pull/63515 for https://github.com/grafana/app-o11y-kwl-endpoint/issues/115 (reduce potential for DOS via large payloads)