### PR TITLE
fix: make requestLimitsMiddleware return 400 instead of 500

### DIFF
--- a/pkg/server/middleware/request_limits.go
+++ b/pkg/server/middleware/request_limits.go
@@ -22,7 +22,7 @@ func (l RequestLimits) Wrap(next http.Handler) http.Handler {
 		reader := io.LimitReader(r.Body, int64(l.maxRequestBodySize)+1)
 		body, err := io.ReadAll(reader)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusInternalServerError)
 			return
 		}
 		if int64(len(body)) > l.maxRequestBodySize {

--- a/pkg/server/middleware/request_limits.go
+++ b/pkg/server/middleware/request_limits.go
@@ -22,11 +22,11 @@ func (l RequestLimits) Wrap(next http.Handler) http.Handler {
 		reader := io.LimitReader(r.Body, int64(l.maxRequestBodySize)+1)
 		body, err := io.ReadAll(reader)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusBadRequest)
 			return
 		}
 		if int64(len(body)) > l.maxRequestBodySize {
-			http.Error(w, fmt.Sprintf("trying to send message larger than max (%d vs %d)", len(body), l.maxRequestBodySize), http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("trying to send message larger than max (%d vs %d)", len(body), l.maxRequestBodySize), http.StatusBadRequest)
 			return
 		}
 

--- a/pkg/server/middleware/request_limits.go
+++ b/pkg/server/middleware/request_limits.go
@@ -26,7 +26,7 @@ func (l RequestLimits) Wrap(next http.Handler) http.Handler {
 			return
 		}
 		if int64(len(body)) > l.maxRequestBodySize {
-			http.Error(w, fmt.Sprintf("trying to send message larger than max (%d vs %d)", len(body), l.maxRequestBodySize), http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("trying to send message larger than max (%d vs %d)", len(body), l.maxRequestBodySize), http.StatusRequestEntityTooLarge)
 			return
 		}
 

--- a/pkg/server/middleware/request_limits_test.go
+++ b/pkg/server/middleware/request_limits_test.go
@@ -35,7 +35,7 @@ func TestRequestLimitsMiddleware(t *testing.T) {
 			expectedStatus:     http.StatusOK,
 		},
 		{
-			name:               "requests with body size greater than max should fail with 400",
+			name:               "requests with body size greater than max should fail with 413",
 			maxRequestBodySize: 0.5 * mb,
 			inputBody:          []byte(strings.Repeat("a", 1*mb)),
 			expectedStatus:     http.StatusRequestEntityTooLarge,

--- a/pkg/server/middleware/request_limits_test.go
+++ b/pkg/server/middleware/request_limits_test.go
@@ -35,10 +35,10 @@ func TestRequestLimitsMiddleware(t *testing.T) {
 			expectedStatus:     http.StatusOK,
 		},
 		{
-			name:               "requests with body size greater than max should fail with 500",
+			name:               "requests with body size greater than max should fail with 400",
 			maxRequestBodySize: 0.5 * mb,
 			inputBody:          []byte(strings.Repeat("a", 1*mb)),
-			expectedStatus:     http.StatusInternalServerError,
+			expectedStatus:     http.StatusBadRequest,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/server/middleware/request_limits_test.go
+++ b/pkg/server/middleware/request_limits_test.go
@@ -38,7 +38,7 @@ func TestRequestLimitsMiddleware(t *testing.T) {
 			name:               "requests with body size greater than max should fail with 400",
 			maxRequestBodySize: 0.5 * mb,
 			inputBody:          []byte(strings.Repeat("a", 1*mb)),
-			expectedStatus:     http.StatusBadRequest,
+			expectedStatus:     http.StatusRequestEntityTooLarge,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Users can accidentally send a large body in the request. This is expected behavior and shouldn't be treated as 500. It is 413

The discussion if we should keep returning 500 in this case for the history: https://raintank-corp.slack.com/archives/C01ME9ZS1SS/p1689582371692869