### PR TITLE
fix: handle timeout and unexpected eof error by returning 408 or 499

### DIFF
--- a/pkg/appcommon/harness.go
+++ b/pkg/appcommon/harness.go
@@ -133,7 +133,7 @@ func New(cfg Config, reg prometheus.Registerer, metricPrefix string, tracer open
 		authMiddleware = middleware.HTTPFakeAuth{}
 	}
 
-	requestLimitsMiddleware := middleware.NewRequestLimitsMiddleware(cfg.ServerConfig.HTTPMaxRequestSizeLimit)
+	requestLimitsMiddleware := middleware.NewRequestLimitsMiddleware(cfg.ServerConfig.HTTPMaxRequestSizeLimit, logger)
 
 	// Middlewares will be wrapped in order
 	middlewares := []middleware.Interface{

--- a/pkg/appcommon/harness.go
+++ b/pkg/appcommon/harness.go
@@ -133,7 +133,7 @@ func New(cfg Config, reg prometheus.Registerer, metricPrefix string, tracer open
 		authMiddleware = middleware.HTTPFakeAuth{}
 	}
 
-	requestLimitsMiddleware := middleware.NewRequestLimitsMiddleware(cfg.ServerConfig.HTTPMaxRequestSizeLimit, logger)
+	requestLimitsMiddleware := middleware.NewRequestLimitsMiddleware(cfg.ServerConfig.HTTPMaxRequestSizeLimit)
 
 	// Middlewares will be wrapped in order
 	middlewares := []middleware.Interface{

--- a/pkg/server/middleware/request_limits.go
+++ b/pkg/server/middleware/request_limits.go
@@ -2,21 +2,32 @@ package middleware
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 
+	"github.com/pkg/errors"
+
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
+const (
+	StatusClientClosedRequest = 499
+)
+
 type RequestLimits struct {
 	maxRequestBodySize int64
+	logger             log.Logger
 }
 
-func NewRequestLimitsMiddleware(maxRequestBodySize int64) *RequestLimits {
+func NewRequestLimitsMiddleware(maxRequestBodySize int64, logger log.Logger) *RequestLimits {
 	return &RequestLimits{
 		maxRequestBodySize: maxRequestBodySize,
+		logger:             logger,
 	}
 }
 
@@ -29,12 +40,24 @@ func (l RequestLimits) Wrap(next http.Handler) http.Handler {
 		body, err := io.ReadAll(reader)
 		if err != nil {
 			level.Warn(log).Log("msg", "failed to read request body", "err", err)
-			http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusInternalServerError)
-			return
+			_ = level.Warn(l.logger).Log("msg", "middleware.RequestLimits.Wrap failed to read request body", "err", err)
+
+			switch {
+			case isNetworkError(err):
+				http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusRequestTimeout)
+				return
+			case errors.Is(err, context.Canceled) || errors.Is(err, io.ErrUnexpectedEOF):
+				http.Error(w, fmt.Sprintf("failed to read request body: %v", err), StatusClientClosedRequest)
+				return
+			default:
+				http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusInternalServerError)
+				return
+			}
 		}
 		if int64(len(body)) > l.maxRequestBodySize {
 			msg := fmt.Sprintf("trying to send message larger than max (%d vs %d)", len(body), l.maxRequestBodySize)
 			level.Warn(log).Log("msg", msg)
+			_ = level.Warn(l.logger).Log("msg", "middleware.RequestLimits.Wrap: "+msg)
 			http.Error(w, msg, http.StatusRequestEntityTooLarge)
 			return
 		}
@@ -43,4 +66,13 @@ func (l RequestLimits) Wrap(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+func isNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	netErr, ok := errors.Cause(err).(net.Error)
+	return ok && netErr.Timeout()
 }

--- a/pkg/server/middleware/request_limits_test.go
+++ b/pkg/server/middleware/request_limits_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -46,7 +45,7 @@ func TestRequestLimitsMiddleware(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			middleware := NewRequestLimitsMiddleware(tc.maxRequestBodySize, log.NewNopLogger())
+			middleware := NewRequestLimitsMiddleware(tc.maxRequestBodySize)
 			handler := middleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
@@ -112,7 +111,7 @@ func TestRequestLimitsMiddlewareReadError(t *testing.T) {
 			expectedStatus: http.StatusInternalServerError,
 		},
 	} {
-		middleware := NewRequestLimitsMiddleware(1*mb, log.NewNopLogger())
+		middleware := NewRequestLimitsMiddleware(1 * mb)
 		handler := middleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))


### PR DESCRIPTION
In case of errors

- unexpected EOF the connection is broken and nothing else can be read (the user has a bad connection, the user closed the request): 499
- read timeout means the connection is there and nothing is being sent - so that would be the disappearing act: user opened the page and gone: 408

we shouldn't return 500, we should return 499 or 408 instead 