### PR TITLE
feat: make request limit middleware optional

### DIFF
--- a/pkg/appcommon/harness.go
+++ b/pkg/appcommon/harness.go
@@ -133,15 +133,17 @@ func New(cfg Config, reg prometheus.Registerer, metricPrefix string, tracer open
 		authMiddleware = middleware.HTTPFakeAuth{}
 	}
 
-	requestLimitsMiddleware := middleware.NewRequestLimitsMiddleware(cfg.ServerConfig.HTTPMaxRequestSizeLimit)
-
 	// Middlewares will be wrapped in order
 	middlewares := []middleware.Interface{
 		tracerMiddleware,
 		instrumentMiddleware,
 		authMiddleware,
 		logMiddleware,
-		requestLimitsMiddleware,
+	}
+
+	if (cfg.ServerConfig.HTTPMaxRequestSizeLimit > 0) {
+		requestLimitsMiddleware := middleware.NewRequestLimitsMiddleware(cfg.ServerConfig.HTTPMaxRequestSizeLimit)
+		middlewares = append(middlewares, requestLimitsMiddleware)
 	}
 
 	srv, err := server.NewServer(logger, cfg.ServerConfig, router, middlewares)


### PR DESCRIPTION
It may make sense for OTLP gateway to not enforce request limit and rely on backends for that.
Currently request limit middleware reads the entire body to check the size, which is slowing things down and is redundant if downstream does it as well. 
This adds  ability to opt out of request limit middleware by setting limit to 0