### PR TITLE
fix: use NewWithLogger in request_limits middleware

### DIFF
--- a/pkg/appcommon/harness.go
+++ b/pkg/appcommon/harness.go
@@ -141,8 +141,8 @@ func New(cfg Config, reg prometheus.Registerer, metricPrefix string, tracer open
 		logMiddleware,
 	}
 
-	if (cfg.ServerConfig.HTTPMaxRequestSizeLimit > 0) {
-		requestLimitsMiddleware := middleware.NewRequestLimitsMiddleware(cfg.ServerConfig.HTTPMaxRequestSizeLimit)
+	if cfg.ServerConfig.HTTPMaxRequestSizeLimit > 0 {
+		requestLimitsMiddleware := middleware.NewRequestLimitsMiddleware(cfg.ServerConfig.HTTPMaxRequestSizeLimit, logger)
 		middlewares = append(middlewares, requestLimitsMiddleware)
 	}
 

--- a/pkg/server/middleware/request_limits_test.go
+++ b/pkg/server/middleware/request_limits_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -45,7 +46,7 @@ func TestRequestLimitsMiddleware(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			middleware := NewRequestLimitsMiddleware(tc.maxRequestBodySize)
+			middleware := NewRequestLimitsMiddleware(tc.maxRequestBodySize, log.NewNopLogger())
 			handler := middleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
@@ -111,7 +112,7 @@ func TestRequestLimitsMiddlewareReadError(t *testing.T) {
 			expectedStatus: http.StatusInternalServerError,
 		},
 	} {
-		middleware := NewRequestLimitsMiddleware(1 * mb)
+		middleware := NewRequestLimitsMiddleware(1*mb, log.NewNopLogger())
 		handler := middleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))


### PR DESCRIPTION
The follow-up on https://github.com/grafana/mimir-proxies/pull/64
If we use `spanlogger.New`, then the default logger is used:

```
"github.com/grafana/mimir/pkg/util/log"
```
```
var (
	// Logger is a shared go-kit logger.
	// TODO: Change all components to take a non-global logger via their constructors.
	// Prefer accepting a non-global logger as an argument.
	Logger = log.NewNopLogger()
)
```
This logger doesn't log to stdout. To see the logs we need to pass app logger to spanlogger