### PR TITLE
feat: internal server becomes not ready when stop signal is received

### DIFF
--- a/pkg/internalserver/internalserver_handler.go
+++ b/pkg/internalserver/internalserver_handler.go
@@ -47,10 +47,8 @@ func Handler(logger log.Logger, cfg Config) (run func() error, stop func(error))
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
-	mux.Handle("/healthz", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		rw.WriteHeader(http.StatusOK)
-		_, _ = rw.Write([]byte("ok"))
-	}))
+	signalHandler := newSignalHandler(cfg.ServerGracefulShutdownTimeout, logger)
+	mux.Handle("/healthz", http.HandlerFunc(NewReadinessHandler(signalHandler, logger)))
 
 	// Pprof.
 	mux.HandleFunc("/debug/pprof/", pprof.Index)

--- a/pkg/internalserver/ready_handler.go
+++ b/pkg/internalserver/ready_handler.go
@@ -1,0 +1,38 @@
+package internalserver
+
+import (
+	"net/http"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+type ReadinessProvider interface {
+	Ready() bool
+}
+
+// NewReadinessHandler returns an endpoint that returns a simple 200 to denote
+// the web server is active
+func NewReadinessHandler(ready ReadinessProvider, logger log.Logger) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var err error
+
+		if ready.Ready() {
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write([]byte("OK"))
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, err = w.Write([]byte("Not ready"))
+		}
+
+		if err != nil {
+			level.Error(logger).Log("msg", "ready endpoint error", "err", err)
+		}
+	}
+}
+
+type AlwaysReady struct{}
+
+func (AlwaysReady) Ready() bool {
+	return true
+}

--- a/pkg/internalserver/signal_handler.go
+++ b/pkg/internalserver/signal_handler.go
@@ -26,8 +26,8 @@ type serverSignalHandler struct {
 	logger        log.Logger
 }
 
-func (dh *serverSignalHandler) Loop() {
-	dh.ready.Store(true)
+func (sh *serverSignalHandler) Loop() {
+	sh.ready.Store(true)
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
@@ -35,28 +35,28 @@ func (dh *serverSignalHandler) Loop() {
 
 	for {
 		select {
-		case <-dh.quit:
+		case <-sh.quit:
 			return
 
 		case <-sigs:
-			level.Info(dh.logger).Log("msg", "=== received SIGINT/SIGTERM ===", "sleep", dh.shutdownDelay)
+			level.Info(sh.logger).Log("msg", "=== received SIGINT/SIGTERM ===", "sleep", sh.shutdownDelay)
 
 			// Not ready anymore.
-			dh.ready.Store(false)
-			if dh.shutdownDelay > 0 {
-				time.Sleep(dh.shutdownDelay)
+			sh.ready.Store(false)
+			if sh.shutdownDelay > 0 {
+				time.Sleep(sh.shutdownDelay)
 			}
 
-			level.Info(dh.logger).Log("msg", "shutting down")
+			level.Info(sh.logger).Log("msg", "shutting down")
 			return
 		}
 	}
 }
 
-func (dh *serverSignalHandler) Stop() {
-	close(dh.quit)
+func (sh *serverSignalHandler) Stop() {
+	close(sh.quit)
 }
 
-func (dh *serverSignalHandler) Ready() bool {
-	return dh.ready.Load()
+func (sh *serverSignalHandler) Ready() bool {
+	return sh.ready.Load()
 }

--- a/pkg/internalserver/signal_handler.go
+++ b/pkg/internalserver/signal_handler.go
@@ -1,0 +1,62 @@
+package internalserver
+
+import (
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+func newSignalHandler(shutdownDelay time.Duration, logger log.Logger) *serverSignalHandler {
+	return &serverSignalHandler{
+		quit:          make(chan struct{}),
+		shutdownDelay: shutdownDelay,
+		logger:        logger,
+	}
+}
+
+type serverSignalHandler struct {
+	quit          chan struct{}
+	ready         atomic.Bool
+	shutdownDelay time.Duration
+	logger        log.Logger
+}
+
+func (dh *serverSignalHandler) Loop() {
+	dh.ready.Store(true)
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigs)
+
+	for {
+		select {
+		case <-dh.quit:
+			return
+
+		case <-sigs:
+			level.Info(dh.logger).Log("msg", "=== received SIGINT/SIGTERM ===", "sleep", dh.shutdownDelay)
+
+			// Not ready anymore.
+			dh.ready.Store(false)
+			if dh.shutdownDelay > 0 {
+				time.Sleep(dh.shutdownDelay)
+			}
+
+			level.Info(dh.logger).Log("msg", "shutting down")
+			return
+		}
+	}
+}
+
+func (dh *serverSignalHandler) Stop() {
+	close(dh.quit)
+}
+
+func (dh *serverSignalHandler) Ready() bool {
+	return dh.ready.Load()
+}


### PR DESCRIPTION
This PR is updating the internalserver implementation to set the service as not ready when a stop signal is received.