### PR TITLE
fix: skip points outside of archive retention on first pass

### DIFF
--- a/pkg/graphite/convert/whisperconverter/daterange.go
+++ b/pkg/graphite/convert/whisperconverter/daterange.go
@@ -3,6 +3,7 @@ package whisperconverter
 import (
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -89,6 +90,16 @@ READLOOP:
 		}
 	}
 
-	fmt.Printf("--start-date %s --end-date %s\n", time.UnixMilli(minTS).Format("2006-01-02"), time.UnixMilli(maxTS).Format("2006-01-02"))
+	terms := []string{}
+
+	if minTS != int64(math.MaxInt64) {
+		terms = append(terms, fmt.Sprintf("--start-date %s", time.UnixMilli(minTS).Format("2006-01-02")))
+	}
+	if maxTS != int64(math.MinInt64) {
+		terms = append(terms, fmt.Sprintf("--end-date %s", time.UnixMilli(maxTS).Format("2006-01-02")))
+	}
+	terms = append(terms, "\n")
+	fmt.Printf(strings.Join(terms, " "))
+
 	wg.Done()
 }

--- a/pkg/graphite/convert/whisperconverter/daterange_test.go
+++ b/pkg/graphite/convert/whisperconverter/daterange_test.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
+	"github.com/go-graphite/go-whisper"
 	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -16,9 +18,17 @@ import (
 
 // This test contains a data due to how we take over STDOUT but it should be harmless.
 func TestCommandDateRange(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("/tmp", "testCommandDateRange*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	// tmpDir, err := os.MkdirTemp("/tmp", "testCommandDateRange*")
+	// require.NoError(t, err)
+	// defer os.RemoveAll(tmpDir)
+	whisper.Now = func() time.Time {
+		t, err := time.Parse("2006-01-02", "2022-06-01")
+		if err != nil {
+			panic(err)
+		}
+		return t
+	}
+	tmpDir := "/tmp"
 
 	fooTimes, err := ToTimes([]string{
 		"2022-05-01",

--- a/pkg/graphite/convert/whisperconverter/test_utils.go
+++ b/pkg/graphite/convert/whisperconverter/test_utils.go
@@ -1,6 +1,7 @@
 package whisperconverter
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -22,13 +23,24 @@ func CreateWhisperFile(path string, timestamps []*time.Time) error {
 	if err != nil {
 		return err
 	}
+	// defer wsp.Close()
 
 	for _, t := range timestamps {
+		fmt.Println("yes?")
 		err = wsp.Update(1.0, int(t.Unix()))
 		if err != nil {
+			fmt.Println(err)
 			return err
 		}
 	}
+
+	wsp.Close()
+
+	// wsp, err = whisper.Open(path)
+	// if err != nil {
+	// 	return err
+	// }
+	// wsp.Dump(true, false)
 
 	return nil
 }

--- a/pkg/graphite/convert/whisperconverter/whisper.go
+++ b/pkg/graphite/convert/whisperconverter/whisper.go
@@ -99,12 +99,12 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 			}
 			// Don't include any points in this archive that are past the retention
 			// period.
-			if p.Timestamp < minArchiveTs {
+			if p.Timestamp <= minArchiveTs {
 				continue
 			}
 			// Don't include any points in this archive that were covered in a higher
 			// resolution archive.
-			if p.Timestamp >= lastMinTs {
+			if p.Timestamp > lastMinTs {
 				break
 			}
 			endIdx = j

--- a/pkg/graphite/convert/whisperconverter/whisper.go
+++ b/pkg/graphite/convert/whisperconverter/whisper.go
@@ -55,17 +55,16 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 	// We want to track the max timestamp of the archives because we know it
 	// virtually represents now() and we won't have newer points.
 	var maxTs, maxTsOffset uint32
-
-	// Also determine the boundaries between archives.
-	lowerBoundTs := make([]uint32, len(archives))
 	for i := range archives {
-		fmt.Println("retention", archives[i].Retention())
 		// All archives share the same maxTs, so only calculate it once.
 		if maxTs == 0 {
 			if i > 0 {
-				// If there are no points in the high-res archives, we have to bump up maxTs
-				// by the retention of the next-highest archive so that this point is validly
-				// in the retention for this archive.
+				// If there are no points in the high-res archives, we have to bump up
+				// maxTs by the difference in retention to the highest archive so that
+				// this point is validly in the retention for this archive. This can
+				// happen when the only points added to a whisper archive are
+				// significantly older than "Now()" at the time of writing, as happens
+				// during our e2e test.
 				maxTsOffset = archives[i].Retention() - archives[0].Retention()
 			}
 			points, err := w.DumpArchive(i)
@@ -79,22 +78,19 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 			}
 		}
 	}
-	fmt.Println("max ts", maxTs, maxTsOffset)
 	maxTs += maxTsOffset
-	fmt.Println("max ts adjusted", maxTs)
 
+	// Also determine the boundaries between archives.
+	lowerBoundTs := make([]uint32, len(archives))
 	for i, a := range archives {
 		if maxTs < a.Retention() {
 			// very big retention, boundary would be < 0, therefore all points are
 			// covered by this archive.
 			lowerBoundTs[i] = 0
 		} else {
-			fmt.Println("lower bound is maxts-retent", maxTs, a.Retention())
 			lowerBoundTs[i] = maxTs - a.Retention()
 		}
 	}
-
-	fmt.Println("bounds", lowerBoundTs)
 
 	// no maxTs means no points. This is not an error.
 	if maxTs == 0 {
@@ -122,21 +118,18 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 		startIdx := -1
 		endIdx := len(points) - 1
 		for j, p := range points {
-			fmt.Println("point", p.Timestamp, p.Value)
 			if p.Timestamp == 0 {
 				continue
 			}
 			// Don't include any points in this archive that are older than the
 			// retention period.
 			if p.Timestamp <= lowerBoundTs[i] {
-				fmt.Println("older than lower bound", p.Timestamp, lowerBoundTs[i], p.Value)
 				continue
 			}
 			// Don't include any points in this archive that are covered in a higher
 			// resolution archive. If the other boundary is zero, it is invalid
 			// so we keep the point.
 			if i > 0 && p.Timestamp > lowerBoundTs[i-1] {
-				fmt.Println("too new for lower bound, skip", p.Timestamp, lowerBoundTs[i-1])
 				break
 			}
 			endIdx = j

--- a/pkg/graphite/convert/whisperconverter/whisper.go
+++ b/pkg/graphite/convert/whisperconverter/whisper.go
@@ -58,6 +58,7 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 	// Its important to remember that the archive with index 0 (first archive)
 	// has the raw data and the highest precision https://graphite.readthedocs.io/en/latest/whisper.html#archives-retention-and-precision
 	seenTs := map[uint32]struct{}{}
+	previousMaxTs := uint32(0)
 	var keptPoints []whisper.Point
 	for i, a := range w.GetArchives() {
 		archivePoints, err := w.DumpArchive(i)
@@ -76,10 +77,12 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 			}
 		}
 
-		if a.Retention() > maxArchiveTs {
-			minArchiveTs = 0
-		} else {
+		if previousMaxTs == 0 {
+			// this is archive 0
 			minArchiveTs = maxArchiveTs - a.Retention()
+		} else {
+			// this is archive 1+
+			minArchiveTs = previousMaxTs
 		}
 
 		for _, p := range archivePoints {

--- a/pkg/graphite/convert/whisperconverter/whisper.go
+++ b/pkg/graphite/convert/whisperconverter/whisper.go
@@ -79,8 +79,12 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 			return nil, fmt.Errorf("failed to dump archive %d from whisper metric %s", i, name)
 		}
 
+		if len(points) == 0 {
+			continue
+		}
+
 		// All archives share the same maxArchiveTs, so only calculate it once.
-		if i == 0 {
+		if maxTs == 0 {
 			for _, p := range points {
 				if p.Timestamp > maxTs {
 					maxTs = p.Timestamp
@@ -107,12 +111,6 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 		keptPointLen := len(keptPoints)
 	POINTLOOP:
 		for _, p := range points {
-			// turn the unix timestamp into a string
-			timeStr  := time.Unix(int64(p.Timestamp), 0).Format("2006-01-02 15:04:05")
-
-			if p.Value > 400 {
-				fmt.Println("archive", i, timeStr, p.Value)
-			}
 			if p.Timestamp == 0 {
 				continue
 			}

--- a/pkg/graphite/convert/whisperconverter/whisper.go
+++ b/pkg/graphite/convert/whisperconverter/whisper.go
@@ -60,12 +60,12 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 		if maxTs == 0 {
 			if i > 0 {
 				// If there are no points in the high-res archives, we have to bump up
-				// maxTs by the difference in retention to the highest archive so that
-				// this point is validly in the retention for this archive. This can
-				// happen when the only points added to a whisper archive are
+				// maxTs by the difference in retention to the next higher archive so
+				// that this point is validly in the retention for this archive. This
+				// can happen when the only points added to a whisper archive are
 				// significantly older than "Now()" at the time of writing, as happens
 				// during our e2e test.
-				maxTsOffset = archives[i].Retention() - archives[0].Retention()
+				maxTsOffset = archives[i-1].Retention()
 			}
 			points, err := w.DumpArchive(i)
 			if err != nil {

--- a/pkg/graphite/convert/whisperconverter/whisper.go
+++ b/pkg/graphite/convert/whisperconverter/whisper.go
@@ -48,11 +48,6 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 		return nil, fmt.Errorf("whisper file contains no archives for metric: %q", name)
 	}
 
-	// Ensure archives are sorted by precision just in case.
-	sort.Slice(archives, func(i, j int) bool {
-		return archives[i].SecondsPerPoint < archives[j].SecondsPerPoint
-	})
-
 	// Dump one precision level at a time and write into the output slice.
 	// Its important to remember that the archive with index 0 (first archive)
 	// has the raw data and the highest precision https://graphite.readthedocs.io/en/latest/whisper.html#archives-retention-and-precision

--- a/pkg/graphite/convert/whisperconverter/whisper.go
+++ b/pkg/graphite/convert/whisperconverter/whisper.go
@@ -62,13 +62,12 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 
 	// Preallocate space for all allPoints in one slice.
 	allPoints := make([]pointWithPrecision, totalPoints)
-	pIdx := 0
 	// Dump one precision level at a time and write into the output slice.
 	// Its important to remember that the archive with index 0 (first archive)
 	// has the raw data and the highest precision https://graphite.readthedocs.io/en/latest/whisper.html#archives-retention-and-precision
 
 	// TODO (sort archives on seconds per point) then keep maxTs per archive and drop all points seen in the previous archive
-
+	idxPoint := 0
 	for i, a := range w.GetArchives() {
 		archivePoints, err := w.DumpArchive(i)
 		if err != nil {
@@ -93,16 +92,14 @@ func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 			minArchiveTs = maxArchiveTs - a.Retention()
 		}
 
-		addedPoints := 0
-		for j, p := range archivePoints {
+		for _, p := range archivePoints {
 			// If the point is older than minArchiveTs then we want to skip it.
 			if p.Timestamp < minArchiveTs {
 				continue
 			}
-			allPoints[pIdx+j] = pointWithPrecision{p, a.SecondsPerPoint}
-			addedPoints++
+			allPoints[idxPoint] = pointWithPrecision{p, a.SecondsPerPoint}
+			idxPoint++
 		}
-		pIdx += addedPoints
 		// TODO sort allpoints by timestamp
 	}
 

--- a/pkg/graphite/convert/whisperconverter/whisper.go
+++ b/pkg/graphite/convert/whisperconverter/whisper.go
@@ -41,14 +41,6 @@ type Archive interface {
 	DumpArchive(int) ([]whisper.Point, error)
 }
 
-// pointWithPrecision is a whisper Point with the precision of the archive it
-// came from. This is used to differentiate when we have duplicate timestamps at
-// different precisions.
-type pointWithPrecision struct {
-	whisper.Point
-	secondsPerPoint uint32
-}
-
 // ReadPoints reads and concatenates all of the points in a whisper Archive.
 func ReadPoints(w Archive, name string) ([]whisper.Point, error) {
 	archives := w.GetArchives()

--- a/pkg/graphite/convert/whisperconverter/whisper_test.go
+++ b/pkg/graphite/convert/whisperconverter/whisper_test.go
@@ -85,36 +85,36 @@ func TestExtractWhisperPoints(t *testing.T) {
 					{
 						whisper.NewPoint(time.Unix(0, 0), 12),
 						whisper.NewPoint(time.Unix(0, 0), 12),
-						whisper.NewPoint(time.Unix(1000, 0), 12),
-						whisper.NewPoint(time.Unix(1001, 0), 42),
+						whisper.NewPoint(time.Unix(1054, 0), 12),
+						whisper.NewPoint(time.Unix(1055, 0), 42),
 						whisper.NewPoint(time.Unix(1060, 0), 2),
-						whisper.NewPoint(time.Unix(1002, 0), 27.5),
+						whisper.NewPoint(time.Unix(1056, 0), 27.5),
 					},
 					{
 						whisper.NewPoint(time.Unix(0, 0), 12),
-						whisper.NewPoint(time.Unix(1004, 0), 1),
+						whisper.NewPoint(time.Unix(1058, 0), 1),
 						whisper.NewPoint(time.Unix(1060, 0), 102),
 						whisper.NewPoint(time.Unix(1121, 0), 4),
 						whisper.NewPoint(time.Unix(0, 0), 0),
-						whisper.NewPoint(time.Unix(1001, 0), 5),
+						whisper.NewPoint(time.Unix(1055, 0), 5),
 					},
 				},
 			},
 			want: []whisper.Point{
 				{
-					Timestamp: 1000,
+					Timestamp: 1054,
 					Value:     12,
 				},
 				{
-					Timestamp: 1001,
+					Timestamp: 1055,
 					Value:     42,
 				},
 				{
-					Timestamp: 1002,
+					Timestamp: 1056,
 					Value:     27.5,
 				},
 				{
-					Timestamp: 1004,
+					Timestamp: 1058,
 					Value:     1,
 				},
 				{
@@ -138,18 +138,18 @@ func TestExtractWhisperPoints(t *testing.T) {
 				points: [][]whisper.Point{
 					{
 						whisper.NewPoint(time.Unix(2002, 0), 4),
-						whisper.NewPoint(time.Unix(1000, 0), 87),
-						whisper.NewPoint(time.Unix(1501, 0), 112),
+						whisper.NewPoint(time.Unix(2000, 0), 87),
+						whisper.NewPoint(time.Unix(2001, 0), 112),
 					},
 				},
 			},
 			want: []whisper.Point{
 				{
-					Timestamp: 1000,
+					Timestamp: 2000,
 					Value:     87,
 				},
 				{
-					Timestamp: 1501,
+					Timestamp: 2001,
 					Value:     112,
 				},
 				{

--- a/pkg/graphite/convert/whisperconverter/whisper_test.go
+++ b/pkg/graphite/convert/whisperconverter/whisper_test.go
@@ -147,7 +147,7 @@ func TestExtractWhisperPoints(t *testing.T) {
 				},
 				points: [][]whisper.Point{
 					{
-						whisper.NewPoint(time.Unix(1020, 0), 20),
+						whisper.NewPoint(time.Unix(1020, 0), 20), // Skipped, this is past the lower bound of this archive.
 						whisper.NewPoint(time.Unix(1021, 0), 21),
 						whisper.NewPoint(time.Unix(1022, 0), 22),
 						whisper.NewPoint(time.Unix(1023, 0), 23),
@@ -160,7 +160,7 @@ func TestExtractWhisperPoints(t *testing.T) {
 						whisper.NewPoint(time.Unix(1030, 0), 30),
 					},
 					{
-						whisper.NewPoint(time.Unix(1009, 0), 9), // This is the lower border of this archive, this point should be kept
+						whisper.NewPoint(time.Unix(1009, 0), 9), // Skipped, this is past the lower bound of this archive.
 						whisper.NewPoint(time.Unix(1012, 0), 12),
 						whisper.NewPoint(time.Unix(1015, 0), 15),
 						whisper.NewPoint(time.Unix(1018, 0), 18),
@@ -172,7 +172,7 @@ func TestExtractWhisperPoints(t *testing.T) {
 					{
 						whisper.NewPoint(time.Unix(1000, 0), 0),
 						whisper.NewPoint(time.Unix(1006, 0), 6),
-						whisper.NewPoint(time.Unix(1009, 0), 99), // skipped because archive 1 has a point at this time
+						whisper.NewPoint(time.Unix(1009, 0), 99), // This is the upper bound of this archive
 						whisper.NewPoint(time.Unix(1012, 0), 12), // skipped
 						whisper.NewPoint(time.Unix(1018, 0), 18), // skipped
 						whisper.NewPoint(time.Unix(1024, 0), 24), // skipped
@@ -191,7 +191,7 @@ func TestExtractWhisperPoints(t *testing.T) {
 				},
 				{
 					Timestamp: 1009,
-					Value:     9,
+					Value:     99,
 				},
 				{
 					Timestamp: 1012,
@@ -204,10 +204,6 @@ func TestExtractWhisperPoints(t *testing.T) {
 				{
 					Timestamp: 1018,
 					Value:     18,
-				},
-				{
-					Timestamp: 1020,
-					Value:     20,
 				},
 				{
 					Timestamp: 1021,

--- a/pkg/graphite/convert/whisperconverter/whisper_test.go
+++ b/pkg/graphite/convert/whisperconverter/whisper_test.go
@@ -134,7 +134,7 @@ func TestExtractWhisperPoints(t *testing.T) {
 			archive: &testArchive{
 				infos: []whisper.ArchiveInfo{
 					// This is what the test will define
-					// 1000     1010     1020     1030
+					// 1030     1020     1010     1000
 					//  [         ]
 					//  [                  ]
 					//  [                           ]
@@ -149,33 +149,33 @@ func TestExtractWhisperPoints(t *testing.T) {
 				},
 				points: [][]whisper.Point{
 					{
-						whisper.NewPoint(time.Unix(1000, 0), 0),
-						whisper.NewPoint(time.Unix(1001, 0), 1),
-						whisper.NewPoint(time.Unix(1002, 0), 2),
-						whisper.NewPoint(time.Unix(1003, 0), 3),
-						whisper.NewPoint(time.Unix(1004, 0), 4),
-						whisper.NewPoint(time.Unix(1005, 0), 5),
-						whisper.NewPoint(time.Unix(1006, 0), 6),
-						whisper.NewPoint(time.Unix(1007, 0), 7),
-						whisper.NewPoint(time.Unix(1008, 0), 8),
-						whisper.NewPoint(time.Unix(1009, 0), 9),
+						whisper.NewPoint(time.Unix(1021, 0), 21),
+						whisper.NewPoint(time.Unix(1022, 0), 22),
+						whisper.NewPoint(time.Unix(1023, 0), 23),
+						whisper.NewPoint(time.Unix(1024, 0), 24),
+						whisper.NewPoint(time.Unix(1025, 0), 25),
+						whisper.NewPoint(time.Unix(1026, 0), 26),
+						whisper.NewPoint(time.Unix(1027, 0), 27),
+						whisper.NewPoint(time.Unix(1028, 0), 28),
+						whisper.NewPoint(time.Unix(1029, 0), 29),
+						whisper.NewPoint(time.Unix(1030, 0), 30),
 					},
 					{
-						whisper.NewPoint(time.Unix(1000, 0), 0), // skipped
-						whisper.NewPoint(time.Unix(1003, 0), 3), // skipped
-						whisper.NewPoint(time.Unix(1006, 0), 6), // skipped
-						whisper.NewPoint(time.Unix(1009, 0), 9), // skipped
 						whisper.NewPoint(time.Unix(1012, 0), 12),
 						whisper.NewPoint(time.Unix(1015, 0), 15),
 						whisper.NewPoint(time.Unix(1018, 0), 18),
+						whisper.NewPoint(time.Unix(1021, 0), 21), // skipped
+						whisper.NewPoint(time.Unix(1024, 0), 24), // skipped
+						whisper.NewPoint(time.Unix(1027, 0), 27), // skipped
+						whisper.NewPoint(time.Unix(1030, 0), 30), // skipped
 					},
 					{
-						whisper.NewPoint(time.Unix(1000, 0), 0),  // skipped
-						whisper.NewPoint(time.Unix(1006, 0), 6),  // skipped
+						whisper.NewPoint(time.Unix(1000, 0), 0),
+						whisper.NewPoint(time.Unix(1006, 0), 6),
 						whisper.NewPoint(time.Unix(1012, 0), 12), // skipped
 						whisper.NewPoint(time.Unix(1018, 0), 18), // skipped
-						whisper.NewPoint(time.Unix(1024, 0), 24),
-						whisper.NewPoint(time.Unix(1030, 0), 30),
+						whisper.NewPoint(time.Unix(1024, 0), 24), // skipped
+						whisper.NewPoint(time.Unix(1030, 0), 30), // skipped
 					},
 				},
 			},
@@ -185,40 +185,8 @@ func TestExtractWhisperPoints(t *testing.T) {
 					Value:     0,
 				},
 				{
-					Timestamp: 1001,
-					Value:     1,
-				},
-				{
-					Timestamp: 1002,
-					Value:     2,
-				},
-				{
-					Timestamp: 1003,
-					Value:     3,
-				},
-				{
-					Timestamp: 1004,
-					Value:     4,
-				},
-				{
-					Timestamp: 1005,
-					Value:     5,
-				},
-				{
 					Timestamp: 1006,
 					Value:     6,
-				},
-				{
-					Timestamp: 1007,
-					Value:     7,
-				},
-				{
-					Timestamp: 1008,
-					Value:     8,
-				},
-				{
-					Timestamp: 1009,
-					Value:     9,
 				},
 				{
 					Timestamp: 1012,
@@ -233,8 +201,40 @@ func TestExtractWhisperPoints(t *testing.T) {
 					Value:     18,
 				},
 				{
+					Timestamp: 1021,
+					Value:     21,
+				},
+				{
+					Timestamp: 1022,
+					Value:     22,
+				},
+				{
+					Timestamp: 1023,
+					Value:     23,
+				},
+				{
 					Timestamp: 1024,
 					Value:     24,
+				},
+				{
+					Timestamp: 1025,
+					Value:     25,
+				},
+				{
+					Timestamp: 1026,
+					Value:     26,
+				},
+				{
+					Timestamp: 1027,
+					Value:     27,
+				},
+				{
+					Timestamp: 1028,
+					Value:     28,
+				},
+				{
+					Timestamp: 1029,
+					Value:     29,
 				},
 				{
 					Timestamp: 1030,

--- a/pkg/graphite/convert/whisperconverter/whisper_test.go
+++ b/pkg/graphite/convert/whisperconverter/whisper_test.go
@@ -78,8 +78,8 @@ func TestExtractWhisperPoints(t *testing.T) {
 			metricName: "mymetric",
 			archive: &testArchive{
 				infos: []whisper.ArchiveInfo{
-					simpleArchiveInfo(6, 1),
-					simpleArchiveInfo(6, 60),
+					simpleArchiveInfo(120, 1),
+					simpleArchiveInfo(4, 60),
 				},
 				points: [][]whisper.Point{
 					{
@@ -91,16 +91,21 @@ func TestExtractWhisperPoints(t *testing.T) {
 						whisper.NewPoint(time.Unix(1056, 0), 27.5),
 					},
 					{
-						whisper.NewPoint(time.Unix(0, 0), 12), // skipped
-						whisper.NewPoint(time.Unix(1058, 0), 1),
+						whisper.NewPoint(time.Unix(0, 0), 12),     // skipped
+						whisper.NewPoint(time.Unix(1058, 0), 1),   // skipped, covered by other archive
 						whisper.NewPoint(time.Unix(1060, 0), 102), // duplicate, the one in the archive above should be kept and this one skipped
-						whisper.NewPoint(time.Unix(1121, 0), 4),
-						whisper.NewPoint(time.Unix(650, 0), 50), // skipped due to being out of retention
+						whisper.NewPoint(time.Unix(650, 0), 50),   // skipped due to being out of retention
 						whisper.NewPoint(time.Unix(1055, 0), 5),
+						whisper.NewPoint(time.Unix(901, 0), 4),
 					},
 				},
 			},
 			want: []whisper.Point{
+				// We do not to any rounding / conversion of time values.
+				{
+					Timestamp: 901,
+					Value:     4,
+				},
 				{
 					Timestamp: 1054,
 					Value:     12,
@@ -114,17 +119,8 @@ func TestExtractWhisperPoints(t *testing.T) {
 					Value:     27.5,
 				},
 				{
-					Timestamp: 1058,
-					Value:     1,
-				},
-				{
 					Timestamp: 1060,
 					Value:     2,
-				},
-				// We do not to any rounding / conversion of time values.
-				{
-					Timestamp: 1121,
-					Value:     4,
 				},
 			},
 		},
@@ -145,9 +141,9 @@ func TestExtractWhisperPoints(t *testing.T) {
 					//  [          XXXXXXXXX]
 					//  [                   XXXXXXXX]
 
-					simpleArchiveInfo(11, 1),
-					simpleArchiveInfo(8, 3),
-					simpleArchiveInfo(7, 6),
+					simpleArchiveInfo(10, 1),
+					simpleArchiveInfo(7, 3),
+					simpleArchiveInfo(6, 6),
 				},
 				points: [][]whisper.Point{
 					{
@@ -272,9 +268,9 @@ func TestExtractWhisperPoints(t *testing.T) {
 					//  [          XXXXXXXXX]
 					//  [                   XXXXXXXX]
 
-					simpleArchiveInfo(11, 1),
-					simpleArchiveInfo(8, 3),
-					simpleArchiveInfo(7, 6),
+					simpleArchiveInfo(10, 1),
+					simpleArchiveInfo(7, 3),
+					simpleArchiveInfo(6, 6),
 				},
 				points: [][]whisper.Point{
 					{},
@@ -283,18 +279,18 @@ func TestExtractWhisperPoints(t *testing.T) {
 					},
 					{
 						whisper.NewPoint(time.Unix(1009, 0), 99), // skipped because archive 1 has a point at this time
-						whisper.NewPoint(time.Unix(1012, 0), 12),
+						whisper.NewPoint(time.Unix(975, 0), 12),
 					},
 				},
 			},
 			want: []whisper.Point{
 				{
-					Timestamp: 1009,
-					Value:     9,
+					Timestamp: 975,
+					Value:     12,
 				},
 				{
-					Timestamp: 1012,
-					Value:     12,
+					Timestamp: 1009,
+					Value:     9,
 				},
 			},
 		},

--- a/pkg/graphite/convert/whisperconverter/whisper_test.go
+++ b/pkg/graphite/convert/whisperconverter/whisper_test.go
@@ -9,14 +9,15 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/mimir-proxies/pkg/graphite/convert"
-	"github.com/grafana/mimir-proxies/pkg/graphite/writeproxy"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/kisielk/whisper-go/whisper"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir-proxies/pkg/graphite/convert"
+	"github.com/grafana/mimir-proxies/pkg/graphite/writeproxy"
 )
 
 func simpleArchiveInfo(points, secondsPerPoint int) whisper.ArchiveInfo {

--- a/pkg/graphite/convert/whisperconverter/whisper_test.go
+++ b/pkg/graphite/convert/whisperconverter/whisper_test.go
@@ -95,7 +95,7 @@ func TestExtractWhisperPoints(t *testing.T) {
 						whisper.NewPoint(time.Unix(1058, 0), 1),   // skipped, covered by other archive
 						whisper.NewPoint(time.Unix(1060, 0), 102), // duplicate, the one in the archive above should be kept and this one skipped
 						whisper.NewPoint(time.Unix(650, 0), 50),   // skipped due to being out of retention
-						whisper.NewPoint(time.Unix(1055, 0), 5),
+						whisper.NewPoint(time.Unix(1055, 0), 5),   // skipped, covered by other archive
 						whisper.NewPoint(time.Unix(901, 0), 4),
 					},
 				},

--- a/pkg/graphite/convert/whisperconverter/whisper_test.go
+++ b/pkg/graphite/convert/whisperconverter/whisper_test.go
@@ -129,6 +129,120 @@ func TestExtractWhisperPoints(t *testing.T) {
 			},
 		},
 		{
+			name:       "single series, multiple archives and retentions, with duplicates and points beyond retention",
+			metricName: "mymetric",
+			archive: &testArchive{
+				infos: []whisper.ArchiveInfo{
+					// This is what the test will define
+					// 1000     1010     1020     1030
+					//  [         ]
+					//  [                  ]
+					//  [                           ]
+					// And this is what the test will expect
+					// 1000     1010     1020     1030
+					//  [XXXXXXXXX]
+					//  [          XXXXXXXXX]
+					//  [                   XXXXXXXX]
+					simpleArchiveInfo(10, 1),
+					simpleArchiveInfo(7, 3),
+					simpleArchiveInfo(6, 6),
+				},
+				points: [][]whisper.Point{
+					{
+						whisper.NewPoint(time.Unix(1000, 0), 0),
+						whisper.NewPoint(time.Unix(1001, 0), 1),
+						whisper.NewPoint(time.Unix(1002, 0), 2),
+						whisper.NewPoint(time.Unix(1003, 0), 3),
+						whisper.NewPoint(time.Unix(1004, 0), 4),
+						whisper.NewPoint(time.Unix(1005, 0), 5),
+						whisper.NewPoint(time.Unix(1006, 0), 6),
+						whisper.NewPoint(time.Unix(1007, 0), 7),
+						whisper.NewPoint(time.Unix(1008, 0), 8),
+						whisper.NewPoint(time.Unix(1009, 0), 9),
+					},
+					{
+						whisper.NewPoint(time.Unix(1000, 0), 0), // skipped
+						whisper.NewPoint(time.Unix(1003, 0), 3), // skipped
+						whisper.NewPoint(time.Unix(1006, 0), 6), // skipped
+						whisper.NewPoint(time.Unix(1009, 0), 9), // skipped
+						whisper.NewPoint(time.Unix(1012, 0), 12),
+						whisper.NewPoint(time.Unix(1015, 0), 15),
+						whisper.NewPoint(time.Unix(1018, 0), 18),
+					},
+					{
+						whisper.NewPoint(time.Unix(1000, 0), 0),  // skipped
+						whisper.NewPoint(time.Unix(1006, 0), 6),  // skipped
+						whisper.NewPoint(time.Unix(1012, 0), 12), // skipped
+						whisper.NewPoint(time.Unix(1018, 0), 18), // skipped
+						whisper.NewPoint(time.Unix(1024, 0), 24),
+						whisper.NewPoint(time.Unix(1030, 0), 30),
+					},
+				},
+			},
+			want: []whisper.Point{
+				{
+					Timestamp: 1000,
+					Value:     0,
+				},
+				{
+					Timestamp: 1001,
+					Value:     1,
+				},
+				{
+					Timestamp: 1002,
+					Value:     2,
+				},
+				{
+					Timestamp: 1003,
+					Value:     3,
+				},
+				{
+					Timestamp: 1004,
+					Value:     4,
+				},
+				{
+					Timestamp: 1005,
+					Value:     5,
+				},
+				{
+					Timestamp: 1006,
+					Value:     6,
+				},
+				{
+					Timestamp: 1007,
+					Value:     7,
+				},
+				{
+					Timestamp: 1008,
+					Value:     8,
+				},
+				{
+					Timestamp: 1009,
+					Value:     9,
+				},
+				{
+					Timestamp: 1012,
+					Value:     12,
+				},
+				{
+					Timestamp: 1015,
+					Value:     15,
+				},
+				{
+					Timestamp: 1018,
+					Value:     18,
+				},
+				{
+					Timestamp: 1024,
+					Value:     24,
+				},
+				{
+					Timestamp: 1030,
+					Value:     30,
+				},
+			},
+		},
+		{
 			name:       "simple series, ordering is fixed",
 			metricName: "mymetric",
 			archive: &testArchive{


### PR DESCRIPTION
We have realized that during first pass and processing of the archive, we are counting in points outside of the retention and this can mess up some calculations. So we are fixing the code to only include points within the expected archive boundaries min timestamp and max timestamp. 

Previous we kept points in a lower archive if that timestamp did not exist in a higher-resolution archive. This was incorrect behavior because the lower archive might be a SUM aggregation, and that results in spike points amidst the original high-res points. Instead, we only take points if there is no higher-resolution archive covering that time span. Similarly, we do not keep any points in a high res archive if those points are covered by a lower-res archive. In effect, we always know which points are valid based on the boundaries between the archives:

```
   MaxT     MinT
0: [XXXXXXXXXX] 1d, 1m
1: [           XXXXXXXXXXXXXXXXX] 1w, 10m
2: [                            XXXXXXXXXXXXX]  1y, 60m
```

Based on this new approach, we can greatly reduce the amount of logic in the ReadSamples function and make it much faster and more space-efficient. We also discovered new edge cases and added tests for those.