### PR TITLE
fix: add optional params to remoteread api for client_golang 1.20.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/grafana/mimir-proxies
 
-go 1.21.8
+go 1.22
+
 toolchain go1.22.5
 
 require (

--- a/pkg/remoteread/api.go
+++ b/pkg/remoteread/api.go
@@ -53,9 +53,9 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, flags *flag.FlagSet) {
 type API interface {
 	Query(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error)
 	QueryRange(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error)
-	Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, v1.Warnings, error)
-	LabelNames(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]string, v1.Warnings, error)
-	LabelValues(ctx context.Context, label string, matches []string, startTime time.Time, endTime time.Time) (model.LabelValues, v1.Warnings, error)
+	Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error)
+	LabelNames(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error)
+	LabelValues(ctx context.Context, label string, matches []string, startTime time.Time, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error)
 }
 
 type errorMappingAPI struct {
@@ -84,19 +84,19 @@ func (e errorMappingAPI) QueryRange(ctx context.Context, query string, r v1.Rang
 	return e.api.QueryRange(ctx, query, r, opts...)
 }
 
-func (e errorMappingAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time) (_ []model.LabelSet, _ v1.Warnings, err error) {
+func (e errorMappingAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) (_ []model.LabelSet, _ v1.Warnings, err error) {
 	defer func() { err = mapAPIError(err) }()
-	return e.api.Series(ctx, matches, startTime, endTime)
+	return e.api.Series(ctx, matches, startTime, endTime, opts...)
 }
 
-func (e errorMappingAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time) (_ []string, _ v1.Warnings, err error) {
+func (e errorMappingAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) (_ []string, _ v1.Warnings, err error) {
 	defer func() { err = mapAPIError(err) }()
-	return e.api.LabelNames(ctx, matches, startTime, endTime)
+	return e.api.LabelNames(ctx, matches, startTime, endTime, opts...)
 }
 
-func (e errorMappingAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time) (_ model.LabelValues, _ v1.Warnings, err error) {
+func (e errorMappingAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (_ model.LabelValues, _ v1.Warnings, err error) {
 	defer func() { err = mapAPIError(err) }()
-	return e.api.LabelValues(ctx, label, matches, startTime, endTime)
+	return e.api.LabelValues(ctx, label, matches, startTime, endTime, opts...)
 }
 
 func NewAPI(cfg Config, options ...APIOption) (API, error) {

--- a/pkg/remoteread/apimock/api.go
+++ b/pkg/remoteread/apimock/api.go
@@ -19,12 +19,19 @@ type API struct {
 }
 
 // LabelNames provides a mock function with given fields: ctx, matches, startTime, endTime
-func (_m *API) LabelNames(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]string, v1.Warnings, error) {
-	ret := _m.Called(ctx, matches, startTime, endTime)
+func (_m *API) LabelNames(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query, ts)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func(context.Context, []string, time.Time, time.Time) []string); ok {
-		r0 = rf(ctx, matches, startTime, endTime)
+	if rf, ok := ret.Get(0).(func(context.Context, []string, time.Time, time.Time, ...v1.Option) []string); ok {
+		r0 = rf(ctx, matches, startTime, endTime, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -32,8 +39,8 @@ func (_m *API) LabelNames(ctx context.Context, matches []string, startTime time.
 	}
 
 	var r1 v1.Warnings
-	if rf, ok := ret.Get(1).(func(context.Context, []string, time.Time, time.Time) v1.Warnings); ok {
-		r1 = rf(ctx, matches, startTime, endTime)
+	if rf, ok := ret.Get(1).(func(context.Context, []string, time.Time, time.Time, ...v1.Option) v1.Warnings); ok {
+		r1 = rf(ctx, matches, startTime, endTime, opts...)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(v1.Warnings)
@@ -41,8 +48,8 @@ func (_m *API) LabelNames(ctx context.Context, matches []string, startTime time.
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, []string, time.Time, time.Time) error); ok {
-		r2 = rf(ctx, matches, startTime, endTime)
+	if rf, ok := ret.Get(2).(func(context.Context, []string, time.Time, time.Time, ...v1.Option) error); ok {
+		r2 = rf(ctx, matches, startTime, endTime, opts...)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -51,12 +58,19 @@ func (_m *API) LabelNames(ctx context.Context, matches []string, startTime time.
 }
 
 // LabelValues provides a mock function with given fields: ctx, label, matches, startTime, endTime
-func (_m *API) LabelValues(ctx context.Context, label string, matches []string, startTime time.Time, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
-	ret := _m.Called(ctx, label, matches, startTime, endTime)
+func (_m *API) LabelValues(ctx context.Context, label string, matches []string, startTime time.Time, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query, ts)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 model.LabelValues
-	if rf, ok := ret.Get(0).(func(context.Context, string, []string, time.Time, time.Time) model.LabelValues); ok {
-		r0 = rf(ctx, label, matches, startTime, endTime)
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string, time.Time, time.Time, ...v1.Option) model.LabelValues); ok {
+		r0 = rf(ctx, label, matches, startTime, endTime, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(model.LabelValues)
@@ -64,8 +78,8 @@ func (_m *API) LabelValues(ctx context.Context, label string, matches []string, 
 	}
 
 	var r1 v1.Warnings
-	if rf, ok := ret.Get(1).(func(context.Context, string, []string, time.Time, time.Time) v1.Warnings); ok {
-		r1 = rf(ctx, label, matches, startTime, endTime)
+	if rf, ok := ret.Get(1).(func(context.Context, string, []string, time.Time, time.Time, ...v1.Option) v1.Warnings); ok {
+		r1 = rf(ctx, label, matches, startTime, endTime, opts...)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(v1.Warnings)
@@ -73,8 +87,8 @@ func (_m *API) LabelValues(ctx context.Context, label string, matches []string, 
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, string, []string, time.Time, time.Time) error); ok {
-		r2 = rf(ctx, label, matches, startTime, endTime)
+	if rf, ok := ret.Get(2).(func(context.Context, string, []string, time.Time, time.Time, ...v1.Option) error); ok {
+		r2 = rf(ctx, label, matches, startTime, endTime, opts...)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -161,12 +175,19 @@ func (_m *API) QueryRange(ctx context.Context, query string, r v1.Range, opts ..
 }
 
 // Series provides a mock function with given fields: ctx, matches, startTime, endTime
-func (_m *API) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, v1.Warnings, error) {
-	ret := _m.Called(ctx, matches, startTime, endTime)
+func (_m *API) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query, r)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 []model.LabelSet
-	if rf, ok := ret.Get(0).(func(context.Context, []string, time.Time, time.Time) []model.LabelSet); ok {
-		r0 = rf(ctx, matches, startTime, endTime)
+	if rf, ok := ret.Get(0).(func(context.Context, []string, time.Time, time.Time, ...v1.Option) []model.LabelSet); ok {
+		r0 = rf(ctx, matches, startTime, endTime, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]model.LabelSet)
@@ -174,8 +195,8 @@ func (_m *API) Series(ctx context.Context, matches []string, startTime time.Time
 	}
 
 	var r1 v1.Warnings
-	if rf, ok := ret.Get(1).(func(context.Context, []string, time.Time, time.Time) v1.Warnings); ok {
-		r1 = rf(ctx, matches, startTime, endTime)
+	if rf, ok := ret.Get(1).(func(context.Context, []string, time.Time, time.Time, ...v1.Option) v1.Warnings); ok {
+		r1 = rf(ctx, matches, startTime, endTime, opts...)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(v1.Warnings)
@@ -183,8 +204,8 @@ func (_m *API) Series(ctx context.Context, matches []string, startTime time.Time
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, []string, time.Time, time.Time) error); ok {
-		r2 = rf(ctx, matches, startTime, endTime)
+	if rf, ok := ret.Get(2).(func(context.Context, []string, time.Time, time.Time, ...v1.Option) error); ok {
+		r2 = rf(ctx, matches, startTime, endTime, opts...)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/pkg/remoteread/measured_api.go
+++ b/pkg/remoteread/measured_api.go
@@ -55,7 +55,7 @@ func (ma *MeasuredAPI) QueryRange(ctx context.Context, query string, r v1.Range,
 	return ma.api.QueryRange(ctx, query, r, opts...)
 }
 
-func (ma *MeasuredAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time) (ls []model.LabelSet, w v1.Warnings, err error) {
+func (ma *MeasuredAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) (ls []model.LabelSet, w v1.Warnings, err error) {
 	sp, ctx := opentracing.StartSpanFromContextWithTracer(ctx, ma.tracer, "remoteread.Series")
 	defer sp.Finish()
 	sp.LogKV("matches", strings.Join(matches, ","), "startTime", startTime, "endTime", endTime)
@@ -63,10 +63,10 @@ func (ma *MeasuredAPI) Series(ctx context.Context, matches []string, startTime, 
 	defer func(t0 time.Time) {
 		ma.recorder.measure("Series", ma.timeNow().Sub(t0), err)
 	}(ma.timeNow())
-	return ma.api.Series(ctx, matches, startTime, endTime)
+	return ma.api.Series(ctx, matches, startTime, endTime, opts...)
 }
 
-func (ma *MeasuredAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time) (s []string, w v1.Warnings, err error) {
+func (ma *MeasuredAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) (s []string, w v1.Warnings, err error) {
 	sp, ctx := opentracing.StartSpanFromContextWithTracer(ctx, ma.tracer, "remoteread.LabelNames")
 	defer sp.Finish()
 	sp.LogKV("matches", strings.Join(matches, ","), "startTime", startTime, "endTime", endTime)
@@ -74,10 +74,10 @@ func (ma *MeasuredAPI) LabelNames(ctx context.Context, matches []string, startTi
 	defer func(t0 time.Time) {
 		ma.recorder.measure("LabelNames", ma.timeNow().Sub(t0), err)
 	}(ma.timeNow())
-	return ma.api.LabelNames(ctx, matches, startTime, endTime)
+	return ma.api.LabelNames(ctx, matches, startTime, endTime, opts...)
 }
 
-func (ma *MeasuredAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time) (v model.LabelValues, w v1.Warnings, err error) {
+func (ma *MeasuredAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (v model.LabelValues, w v1.Warnings, err error) {
 	sp, ctx := opentracing.StartSpanFromContextWithTracer(ctx, ma.tracer, "remoteread.LabelValues")
 	defer sp.Finish()
 	sp.LogKV("label", label, "matches", strings.Join(matches, ","), "startTime", startTime, "endTime", endTime)
@@ -85,5 +85,5 @@ func (ma *MeasuredAPI) LabelValues(ctx context.Context, label string, matches []
 	defer func(t0 time.Time) {
 		ma.recorder.measure("LabelValues", ma.timeNow().Sub(t0), err)
 	}(ma.timeNow())
-	return ma.api.LabelValues(ctx, label, matches, startTime, endTime)
+	return ma.api.LabelValues(ctx, label, matches, startTime, endTime, opts...)
 }


### PR DESCRIPTION
https://github.com/prometheus/client_golang/pull/1544 changed the remoteread api interface to add optional params (going from `1.19.0` to `1.20.0`)

Somehow `dependabot` missed this and allowed the `client_golang` package to be updated.

This should bring `mimir-proxies` in-line with `client_golang` `1.20.x`.