### PR TITLE
chore: switch PR title linting to grafana/shared-workflows action

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -1,6 +1,5 @@
-# .github/workflows/conventional-pr.yml
-
 name: conventional-pr
+
 on:
   pull_request:
     branches:
@@ -10,25 +9,14 @@ on:
       - opened
       - edited
       - synchronize
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   lint-pr:
-    permissions:
-      contents: read
-      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      # check for the most recent release: https://github.com/CondeNast/conventional-pull-request-action/releases
-      # replace vX.X.X below with the most recently released version
-      - uses: CondeNast/conventional-pull-request-action@3ce30fdb4d2beef8b941f23a1114dd8188eba082 # v0.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # to override config-conventional rules, specify a relative path to your rules module, actions/checkout is required for this setting!
-          commitlintRulesPath: "./commitlint.rules.js" # default: undefined
-          # if the PR contains a single commit, fail if the commit message and the PR title do not match
-          commitTitleMatch: "false"
-          # if you squash merge PRs and enabled "Default to PR title for squash merge commits", you can disable all linting of commits
-          ignoreCommits: "true"
+      - name: Lint PR title
+        uses: grafana/shared-workflows/actions/lint-pr-title@0239db2665246f3b078d8d9166e4d8f09c071cae # lint-pr-title/v1.2.2


### PR DESCRIPTION
## Summary

Replaces `CondeNast/conventional-pull-request-action` with the first-party [`grafana/shared-workflows/actions/lint-pr-title`](https://github.com/grafana/shared-workflows/tree/main/actions/lint-pr-title) in [.github/workflows/conventional-pr.yml](https://github.com/grafana/mimir-graphite/blob/main/.github/workflows/conventional-pr.yml).

**Why switch:**

- The previous action is effectively unmaintained: [latest release v0.2.0 was 2023-01-03](https://github.com/CondeNast/conventional-pull-request-action/releases), 16 stars, tiny community. Inside the grafana org it has barely any users; every other team has already moved on.
- The Grafana first-party action is maintained by Platform Productivity and used widely across the org (alloy, tanka, loki, slo, irm, chatops, faro-web-sdk, grafana-csp-app, app-o11y-kwl, github-action-required-reviews, …). First-party supply chain, larger audience for vulnerability discovery, follows Grafana's [GitHub Actions security hardening guidance](https://github.com/grafana/deployment_tools/blob/master/docs/platform/continuous-integration/README.md#follow-the-github-actions-security-best-practices) by default.

**Drive-by cleanups in the same change:**

- Drops `commitlintRulesPath: "./commitlint.rules.js"` — that file does not exist in the repo; the setting was inert. The new action ships [a default `commitlint.config.js`](https://github.com/grafana/shared-workflows/blob/main/actions/lint-pr-title/commitlint.config.js) extending `@commitlint/config-conventional` plus Grafana-house-style rules.
- Drops the `actions/checkout` step — the new action does its own internal checkout of shared-workflows. We never needed the repo on disk because the action only inspects PR metadata.
- Drops the stale `# replace vX.X.X below with the most recently released version` comment.

**Behavioral changes to expect:**

The new defaults are stricter than the (effectively-empty) old config. After this change, PR titles must:

- Start with a [conventional commit type](https://github.com/grafana/shared-workflows/blob/main/actions/lint-pr-title/commitlint.config.js) from: `build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test`.
- Use lower-case after the colon (`fix: correct typo` ✅; `fix: Correct typo` ❌).
- Be ≤100 characters.

The same change is being applied in [grafana/transmog#2652](https://github.com/grafana/transmog/pull/2652) and [grafana/datadog-translation-tools](https://github.com/grafana/datadog-translation-tools/pulls?q=is%3Apr+chore%3A+switch+PR+title+linting).

## Test plan

- [x] SHA pin verified against `lint-pr-title/v1.2.2` in `grafana/shared-workflows`.
- [x] Confirmed `commitlint.rules.js` is not present anywhere in the repo.
- [x] Once this PR is open, the new action will run against this very PR title (`chore: switch PR title linting to grafana/shared-workflows action`) — that itself is the end-to-end test.

Coded with Claude Opus 4.7.